### PR TITLE
Updated closeRE regex so that it stops returning false negatives.

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,5 +203,5 @@ var closeRE = RegExp('^(' + [
   'area', 'base', 'basefont', 'bgsound', 'br', 'col', 'command', 'embed',
   'frame', 'hr', 'img', 'input', 'isindex', 'keygen', 'link', 'meta', 'param',
   'source', 'track', 'wbr'
-].join('|') + ')$')
+].join('|') + ')(?:[\.#][a-zA-Z0-9\u007F-\uFFFF_:-]+)*$')
 function selfClosing (tag) { return closeRE.test(tag) }


### PR DESCRIPTION
When a tag that is written in the 'tagName#id.class' shorthand format (which is accepted by functions such as 'virtual-dom/h') is passed into `selfClosing`, the result is always `false`, even if the tagName itself is a valid self-closing tag.

**Before**
```js
selfClosing('div');               // false
selfClosing('div#thing');         // false
selfClosing('div.thing');         // false
selfClosing('div#thing.thing');   // false
selfClosing('input');             // true
selfClosing('input.thing');       // false *
selfClosing('input#thing');       // false *
selfClosing('input#thing.thing'); // false *
```
\* false negatives

**After**
```js
selfClosing('div');               // false
selfClosing('div#thing');         // false
selfClosing('div.thing');         // false
selfClosing('div#thing.thing');   // false
selfClosing('input');             // true
selfClosing('input.thing');       // true
selfClosing('input#thing');       // true
selfClosing('input#thing.thing'); // true
```

This change updates the regex to match only the tagName component of the tag shorthand, ensuring that `selfClosing` returns the correct result.

I would have committed my tests for this change, but I didn't feel comfortable exposing the `selfClosing` API as you seem to want to keep this as a simple, single-file module.