### PR TITLE
If no child elements exist call h with undefined instead of []

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = function (h, opts) {
         var ix = stack[stack.length-1][1]
         if (stack.length > 1) {
           stack.pop()
-          stack[stack.length-1][0][2][ix] = h(cur[0], cur[1], cur[2])
+          stack[stack.length-1][0][2][ix] = h(cur[0], cur[1], cur[2].length ? cur[2] : undefined)
         }
       } else if (s === OPEN) {
         var c = [p[1],{},[]]
@@ -72,7 +72,7 @@ module.exports = function (h, opts) {
         if (selfClosing(cur[0]) && stack.length) {
           var ix = stack[stack.length-1][1]
           stack.pop()
-          stack[stack.length-1][0][2][ix] = h(cur[0], cur[1], cur[2])
+          stack[stack.length-1][0][2][ix] = h(cur[0], cur[1], cur[2].length ? cur[2] : undefined)
         }
       } else if (s === VAR && p[1] === TEXT) {
         if (p[2] === undefined || p[2] === null) p[2] = ''

--- a/test/children.js
+++ b/test/children.js
@@ -1,0 +1,42 @@
+var test = require('tape')
+var vdom = require('virtual-dom')
+var hyperx = require('../')
+var hx = hyperx(vdom.h)
+
+test('1 child', function (t) {
+  var tree = hx`<div><span>foobar</span></div>`
+  t.equal(vdom.create(tree).toString(), '<div><span>foobar</span></div>')
+  t.end()
+})
+
+test('no children', function (t) {
+  var tree = hx`<img href="xxx">`
+  t.equal(vdom.create(tree).toString(), '<img href="xxx" />')
+  t.end()
+})
+
+test('multiple children', function (t) {
+  var html = `<div>
+    <h1>title</h1>
+    <div>
+      <ul>
+        <li>
+          <a href="#">click</a>
+        </li>
+      </ul>
+    </div>
+  </div>`
+  var tree = hx`
+  <div>
+    <h1>title</h1>
+    <div>
+      <ul>
+        <li>
+          <a href="#">click</a>
+        </li>
+      </ul>
+    </div>
+  </div>`
+  t.equal(vdom.create(tree).toString(), html)
+  t.end()
+})


### PR DESCRIPTION
React complains if children is sent as an empty array instead of undefined.

```javascript
hx`<img href=${href}>`
```
Results in
Warning: img is a void element tag and must not have `children` or use `props.dangerouslySetInnerHTML`. Check the render method of null.

This pull request sends the children array only if there are any and the tests pass.

