### PR TITLE
Multiple properties support

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,11 +45,20 @@ module.exports = function (h, opts) {
         stack.push([c,cur[2].length-1])
       } else if (s === ATTR_KEY || (s === VAR && p[1] === ATTR_KEY)) {
         var key = ''
+        var copyKey
         for (; i < parts.length; i++) {
           if (parts[i][0] === ATTR_KEY) {
             key = concat(key, parts[i][1])
           } else if (parts[i][0] === VAR && parts[i][1] === ATTR_KEY) {
-            key = concat(key, parts[i][2])
+            if (typeof parts[i][2] === 'object' && !key) {
+              for(copyKey in parts[i][2]) {
+                if (parts[i][2].hasOwnProperty(copyKey) && !cur[1][copyKey]) {
+                  cur[1][copyKey] = parts[i][2][copyKey]
+                }
+              }
+            } else {
+              key = concat(key, parts[i][2])
+            }
           } else break
         }
         for (; i < parts.length; i++) {

--- a/test/key.js
+++ b/test/key.js
@@ -34,3 +34,24 @@ test('pre post key', function (t) {
   t.equal(vdom.create(tree).toString(), '<input type="text" />')
   t.end()
 })
+
+test('multiple keys', function (t) {
+  var props = {
+    type: 'text',
+    'data-special': 'true'
+  }
+  var key = 'data-'
+  var value = 'bar'
+  var tree = hx`<input ${props} ${key}foo=${value}>`
+  t.equal(vdom.create(tree).toString(), '<input type="text" data-special="true" data-foo="bar" />')
+  t.end()
+})
+
+test('multiple keys dont overwrite existing ones', function (t) {
+  var props = {
+    type: 'text'
+  }
+  var tree = hx`<input type="date" ${props}>`
+  t.equal(vdom.create(tree).toString(), '<input type="date" />')
+  t.end()
+})


### PR DESCRIPTION
In react you can use the [spread] operator like so 

```javascript
<Element {...this.props} />
```
Unfortunately 
```javascript
hx`<Element ${...this.props} />`
```
isn't valid... However I propose

```javascript
hx`<Element ${this.props} />`
```
As no key is given this can be handled in the parse which this pull request handles (hopefully in an ok way)

I have written to tests for this new functionality.

[spread]:https://facebook.github.io/react/docs/jsx-spread.html