### PR TITLE
Narrow the list of SVG tags to known self closing ones

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,19 +224,15 @@ var closeRE = RegExp('^(' + [
   'frame', 'hr', 'img', 'input', 'isindex', 'keygen', 'link', 'meta', 'param',
   'source', 'track', 'wbr',
   // SVG TAGS
-  'altGlyph', 'altGlyphDef', 'altGlyphItem', 'animate', 'animateColor',
-  'animateMotion', 'animateTransform', 'circle', 'clipPath', 'color-profile',
-  'cursor', 'defs', 'desc', 'ellipse', 'feBlend', 'feColorMatrix',
-  'feComponentTransfer', 'feComposite','feConvolveMatrix', 'feDiffuseLighting',
-  'feDisplacementMap', 'feDistantLight', 'feFlood', 'feFuncA', 'feFuncB',
-  'feFuncG', 'feFuncR', 'feGaussianBlur', 'feImage', 'feMerge', 'feMergeNode',
-  'feMorphology', 'feOffset', 'fePointLight', 'feSpecularLighting',
-  'feSpotLight', 'feTile', 'feTurbulence', 'filter', 'font', 'font-face',
-  'font-face-format', 'font-face-name', 'font-face-src', 'font-face-uri',
-  'foreignObject', 'glyph', 'glyphRef', 'hkern', 'image', 'line',
-  'linearGradient', 'marker', 'mask', 'metadata', 'missing-glyph', 'mpath',
-  'path', 'pattern', 'polygon', 'polyline', 'radialGradient', 'rect',
-  'set', 'stop', 'switch', 'symbol', 'textPath', 'tref',
-  'tspan', 'use', 'view', 'vkern'
+  'animate', 'animateTransform', 'circle', 'cursor', 'desc', 'ellipse',
+  'feBlend', 'feColorMatrix', 'feComponentTransfer', 'feComposite',
+  'feConvolveMatrix', 'feDiffuseLighting', 'feDisplacementMap',
+  'feDistantLight', 'feFlood', 'feFuncA', 'feFuncB', 'feFuncG', 'feFuncR',
+  'feGaussianBlur', 'feImage', 'feMerge', 'feMergeNode', 'feMorphology',
+  'feOffset', 'fePointLight', 'feSpecularLighting', 'feSpotLight', 'feTile',
+  'feTurbulence', 'font-face-format', 'font-face-name', 'font-face-uri',
+  'glyph', 'glyphRef', 'hkern', 'image', 'line', 'missing-glyph', 'mpath',
+  'path', 'polygon', 'polyline', 'rect', 'set', 'stop', 'tref', 'use', 'view',
+  'vkern'
 ].join('|') + ')(?:[\.#][a-zA-Z0-9\u007F-\uFFFF_:-]+)*$')
 function selfClosing (tag) { return closeRE.test(tag) }


### PR DESCRIPTION
Ref https://github.com/substack/hyperx/pull/19#issuecomment-192161066

I looked into each tag to narrow down the list of tags known to self close. They are my best guess by looking at MDN, the specification and google searches of usage.

I removed the following tags as they are marked deprecated:
```js
'altGlyph', 'altGlyphDef', 'altGlyphItem', 'animateColor',
```

I removed these tags as they are not self closing:
```js
'animateMotion', 'clipPath', 'defs', 'filter', 'font', 'font-face', 'font-face-src',
'foreignObject', 'linearGradient', 'marker', 'mask', 'metadata', 'pattern',
'radialGradient', 'switch', 'symbol', 'textPath', 'tspan',
```

I removed this tag as it appears no browser supports it:
```js
'color-profile',
```