### PR TITLE
Remove feMerge from self closing

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ var closeRE = RegExp('^(' + [
   'feBlend', 'feColorMatrix', 'feComponentTransfer', 'feComposite',
   'feConvolveMatrix', 'feDiffuseLighting', 'feDisplacementMap',
   'feDistantLight', 'feFlood', 'feFuncA', 'feFuncB', 'feFuncG', 'feFuncR',
-  'feGaussianBlur', 'feImage', 'feMerge', 'feMergeNode', 'feMorphology',
+  'feGaussianBlur', 'feImage', 'feMergeNode', 'feMorphology',
   'feOffset', 'fePointLight', 'feSpecularLighting', 'feSpotLight', 'feTile',
   'feTurbulence', 'font-face-format', 'font-face-name', 'font-face-uri',
   'glyph', 'glyphRef', 'hkern', 'image', 'line', 'missing-glyph', 'mpath',


### PR DESCRIPTION
Turns out `feMerge` is not self closing:
https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feMerge

Related to https://github.com/shama/bel/issues/23#issuecomment-206044732

Thanks!