### PR TITLE
Fix unquoted attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,7 +201,7 @@ module.exports = function (h, opts) {
           state = ATTR_VALUE
           i--
         } else if (state === ATTR_VALUE && /\s/.test(c)) {
-          res.push([ATTR_BREAK],[ATTR_VALUE,reg])
+          res.push([ATTR_VALUE,reg],[ATTR_BREAK])
           reg = ''
           state = ATTR
         } else if (state === ATTR_VALUE || state === ATTR_VALUE_SQ

--- a/test/attr.js
+++ b/test/attr.js
@@ -26,3 +26,39 @@ test('boolean attribute preceded by normal attribute', function (t) {
   t.equal(vdom.create(tree).toString(), '<video volume="50" autoplay="autoplay"></video>')
   t.end()
 })
+
+test('unquoted attribute', function (t) {
+  var tree = hx`<div class=test></div>`
+  t.equal(vdom.create(tree).toString(), '<div class="test"></div>')
+  t.end()
+})
+
+test('unquoted attribute preceded by boolean attribute', function (t) {
+  var tree = hx`<div hidden dir=ltr></div>`
+  t.equal(vdom.create(tree).toString(), '<div hidden="hidden" dir="ltr"></div>')
+  t.end()
+})
+
+test('unquoted attribute succeeded by boolean attribute', function (t) {
+  var tree = hx`<div dir=ltr hidden></div>`
+  t.equal(vdom.create(tree).toString(), '<div dir="ltr" hidden="hidden"></div>')
+  t.end()
+})
+
+test('unquoted attribute preceded by normal attribute', function (t) {
+  var tree = hx`<div id="test" class=test></div>`
+  t.equal(vdom.create(tree).toString(), '<div id="test" class="test"></div>')
+  t.end()
+})
+
+test('unquoted attribute succeeded by normal attribute', function (t) {
+  var tree = hx`<div id=test class="test"></div>`
+  t.equal(vdom.create(tree).toString(), '<div id="test" class="test"></div>')
+  t.end()
+})
+
+test('consecutive unquoted attributes', function (t) {
+  var tree = hx`<div id=test class=test></div>`
+  t.equal(vdom.create(tree).toString(), '<div id="test" class="test"></div>')
+  t.end()
+})


### PR DESCRIPTION
Not entirely sure in which case `[ATTR_BREAK],[ATTR_VALUE,reg]` made sense, so I presume it might be a mistake? I base this on not being able to find a path through the "node synthesizer" that fits a `ATTR_BREAK` followed by a `ATTR_VALUE`.