### PR TITLE
Leave interpreting attribute values to the renderer

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,9 @@ module.exports = function (h, opts) {
             else cur[1][key] = concat(cur[1][key], parts[i][1])
           } else if (parts[i][0] === VAR
           && (parts[i][1] === ATTR_VALUE || parts[i][1] === ATTR_KEY)) {
-            if (!cur[1][key]) cur[1][key] = strfn(parts[i][2])
+            if (!cur[1][key])
+              if (parts[i][1] === ATTR_KEY) cur[1][key] = strfn(parts[i][2])
+              else cur[1][key] = parts[i][2]
             else cur[1][key] = concat(cur[1][key], parts[i][2])
           } else {
             if (key.length && !cur[1][key] && i === j

--- a/test/attr.js
+++ b/test/attr.js
@@ -9,6 +9,24 @@ test('class', function (t) {
   t.end()
 })
 
+test('undefined attribute value', function (t) {
+  var tree = hx`<div data-meh=${undefined}></div>`
+  t.equal(vdom.create(tree).toString(), '<div></div>')
+  t.end()
+})
+
+test('empty string attribute value', function (t) {
+  var tree = hx`<div data-meh=${''}></div>`
+  t.equal(vdom.create(tree).toString(), '<div data-meh=""></div>')
+  t.end()
+})
+
+test('null attribute value', function (t) {
+  var tree = hx`<div data-meh=${null}></div>`
+  t.equal(vdom.create(tree).toString(), '<div></div>')
+  t.end()
+})
+
 test('boolean attribute', function (t) {
   var tree = hx`<video autoplay></video>`
   t.equal(vdom.create(tree).toString(), '<video autoplay="autoplay"></video>')

--- a/test/attr.js
+++ b/test/attr.js
@@ -1,5 +1,6 @@
 var test = require('tape')
 var vdom = require('virtual-dom')
+var hyperscript = require('hyperscript')
 var hyperx = require('../')
 var hx = hyperx(vdom.h)
 
@@ -18,6 +19,15 @@ test('undefined attribute value', function (t) {
 test('empty string attribute value', function (t) {
   var tree = hx`<div data-meh=${''}></div>`
   t.equal(vdom.create(tree).toString(), '<div data-meh=""></div>')
+  t.end()
+})
+
+// running this test with hyperscript because it
+// breaks with virtual-dom (with "str.replace is not a function")
+test('false attribute value', function (t) {
+  var hx = hyperx(hyperscript)
+  var tree = hx`<div data-meh=${false}></div>`
+  t.equal(tree.outerHTML, '<div data-meh=""></div>')
   t.end()
 })
 


### PR DESCRIPTION
This is a PR for #27 which changes the default behaviour of attribute values.

Now it will leave the interpreting of the attribute values to the renderer, such like `<div x=${null}></div>` will pass attributes as `{x: null}` to the renderer instead of `{x: 'null'}` as it does before this PR.

An important note may be that `null` and `undefined` as values, with virtual-dom (^2.1.1), removes the attribute entirely, while `false` instead throws an exception because it attempts to do some entity serialization.

Behaviour is different using hyperscript which simply makes an attribute with an empty string value instead.