### PR TITLE
Add better character range for attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ module.exports = function (h, opts) {
           state = ATTR
         } else if (state === OPEN) {
           reg += c
-        } else if (state === ATTR && /[\w-]/.test(c)) {
+        } else if (state === ATTR && /[^\s"'=/]/.test(c)) {
           state = ATTR_KEY
           reg = c
         } else if (state === ATTR && /\s/.test(c)) {

--- a/test/attr.js
+++ b/test/attr.js
@@ -62,3 +62,15 @@ test('consecutive unquoted attributes', function (t) {
   t.equal(vdom.create(tree).toString(), '<div id="test" class="test"></div>')
   t.end()
 })
+
+test('strange leading character attributes', function (t) {
+  var tree = hx`<div @click='test' :href='/foo'></div>`
+  t.equal(vdom.create(tree).toString(), '<div @click="test" :href="/foo"></div>')
+  t.end()
+})
+
+test('strange inbetween character attributes', function (t) {
+  var tree = hx`<div f@o='bar' b&z='qux'></div>`
+  t.equal(vdom.create(tree).toString(), `<div f@o="bar" b&z="qux"></div>`)
+  t.end()
+})


### PR DESCRIPTION
From my understand in the [HTML syntax spec on attributes](https://www.w3.org/TR/html5/syntax.html#attributes-0), a wider range of characters can be supported.

For example in Vue, you have things like `<div @click=...>`, or `<div :href='foo'>`.  I'm building something with similar syntax and uses hyperx.

Edit: It's worth mentioning these don't actually go to the DOM (which would probably make them invalid, over `data-*`).  They are processed down to regular attributes.