### PR TITLE
Add support for comments

### DIFF
--- a/test/comment.js
+++ b/test/comment.js
@@ -1,0 +1,51 @@
+var test = require('tape')
+var hyperx = require('../')
+var hx = hyperx(createElement)
+var hxc = hyperx(createElement, {comments: true})
+
+function createElement(tag, props, children) {
+  if (tag === '!--') {
+    return `<!--${props.comment}-->`
+  }
+  return `<${tag}>${children ? children.join('') : ''}</${tag}>`
+}
+
+test('1 comment', function (t) {
+  var tree = hxc`<!-- test -->`
+  t.equal(tree, '<!-- test -->')
+  t.end()
+})
+
+test('with crazy characters', function (t) {
+  var tree = hxc`<!-- .-_<>|[]{}"' -->`
+  t.equal(tree, '<!-- .-_<>|[]{}"\' -->')
+  t.end()
+})
+
+test('as child', function (t) {
+  var tree = hxc`<div><!-- child --></div>`
+  t.equal(tree, '<div><!-- child --></div>')
+  t.end()
+})
+
+test('many comments', function (t) {
+  var html = `<div>
+    <!-- foo -->
+    <span>bar</span>
+    <!-- baz -->
+  </div>`
+  var tree = hxc`
+  <div>
+    <!-- foo -->
+    <span>bar</span>
+    <!-- baz -->
+  </div>`
+  t.equal(tree, html)
+  t.end()
+})
+
+test('excluded by default', function (t) {
+  var tree = hx`<div><!-- comment --></div>`
+  t.equal(tree, '<div></div>')
+  t.end()
+})


### PR DESCRIPTION
Large views written in hyperx can easily become quite messy, especially with nested expressions. Comments can help clear things up and later be removed in production using tools such as [hyperxify](https://github.com/substack/hyperxify) or [yo-yoify](https://github.com/shama/yo-yoify). Comments are disabled by default so as not to brake any existing implementations, though the result will differ as hyperx currently can't handle comments at all and output gets kind of messed up. With this change comments will simply be excluded unless otherwise specified in the options.

See an example implementation in bel: https://github.com/tornqvist/bel/commit/dc647d5070d6da7b3d73694423ff06d11832cfc4

Before:
```javascript
const { createElement }  = require('bel')
const hyperx = require('hyperx')
const hx = hyperx(createElement)
const tree = hx`<div><!--this is a comment --></div>`
tree.toString() // => '<div><!-- this="this" is="is" a="a" comment="comment" --="--"></!--></div>'
```

After:
```javascript
const { createElement }  = require('bel')
const hyperx = require('hyperx')
const hx = hyperx(createElement, {comments: true})
const tree = hx`<div><!-- this is a comment --></div>`
tree.toString() // => '<div><!-- this is a comment --></div>'
```

Since the comment element is kind of special and I didn't want to mess around with the structure, a comment node is represented with the tag `!--` and the (fake) attribute `comment`:

```javascript
function createElement(tag, props, children) {
  console.log(arguments) // [ '0': '!--', '1': { comment: ' this is a comment ' }, '2': undefined ]
}
const hx = hyperx(createElement, {comments: true})
hx`<!-- this is a comment -->`
```