### PR TITLE
Close/self-closing foreign elements

### DIFF
--- a/test/svg.js
+++ b/test/svg.js
@@ -19,3 +19,28 @@ test('svg mixed with html', function (t) {
   t.equal(vdom.create(tree).toString(), expected)
   t.end()
 })
+
+test('svg mixed with html and close / self-closing tags', function (t) {
+  var expected = `<div>
+    <h3>test</h3>
+    <svg width="150" height="100" viewBox="0 0 3 2">
+      <use id="test"></use>
+      <rect width="1" height="2" x="0" fill="#008d46"></rect>
+      <use id="test"></use>
+      <rect width="1" height="2" x="0" fill="#008d46"></rect>
+      <use id="test"></use>
+    </svg>
+  </div>`
+  var tree = hx`<div>
+    <h3>test</h3>
+    <svg width="150" height="100" viewBox="0 0 3 2">
+      <use id="test"></use>
+      <rect width="1" height="2" x="0" fill="#008d46"></rect>
+      <use id="test"/>
+      <rect width="1" height="2" x="0" fill="#008d46"/>
+      <use id="test"></use>
+    </svg>
+  </div>`
+  t.equal(vdom.create(tree).toString(), expected)
+  t.end()
+})


### PR DESCRIPTION
This first commit is a failing test case for valid SVG. Foreign elements can per the spec be self-closing or have a close tag, but currently `hyperx` only seem to accept most SVG tags as self closing. Fixing this test should also resolve #41 