### PR TITLE
Strict Mode Actually Worth It

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict'
 var attrToProp = require('hyperscript-attribute-to-property')
 
 var VAR = 0, TEXT = 1, OPEN = 2, CLOSE = 3, ATTR = 4


### PR DESCRIPTION
On less than the latest-and-greatest, V8-TurboFan Chrome, performance tracing runs of apps bundling hyperx produce the dismaying notice "Not optimized: Bad value context for arguments value" for functions returned by hyperx.  Best I can tell, V8-Crankshaft bails on optimizing the functions because of the way they use `arguments`, and the fact that vanilla JS treats `arguments[0]` as an alias for `x` in `function (x) { ... }`.  This causes problems when references from `arguments` get passed on to other functions.

I've spent a little time scratching my head, trying various approaches, like allocating a new `Array` and copying references over from `arguments`, to avoid the issue.  Someone else might be able to do that more reliably.  And anyone who cares to try, or comes upon this later, might like to know that Node.js has a nifty `--trace_deopt` flag to print V8's warnings.

But it occurred to me that it's far easier to just opt into Strict Mode, where argument aliasing is not a thing.  I've confirmed that `'use strict'` coaxes V8-Crankshaft into optimizing the functions, which is a pretty big win, considering when and how often those functions run.  And that the tests all pass.

That's a lot of background for a one-line patch adding the Strict Mode statement.  But I wouldn't usually send such a thing---I don't use Strict Mode much in my own code, and have seen a fair number of irksome "support `--use_strict`" GitHub issues.  Here I get the feeling it might make sense.

Thanks,

K